### PR TITLE
patch: 2.0.0 - test-solution-fix_and_various-typescript-fixes

### DIFF
--- a/lib/dust-report-worker.ts
+++ b/lib/dust-report-worker.ts
@@ -98,7 +98,7 @@ const handleWaitingTestsInWorker = async (system: SystemTests, correspondingSyst
 const report: WithId<Report> = workerData;
 
 const logContext = {
-  prefix: `dust-report-worker - Thread Id: ${threadId} - Report Id: ${report._id} - Caller: ${report.caller.upn} - User: ${report.user.userPrincipalName}`
+  prefix: `dust-report-worker - Thread Id: ${threadId} - Report Id: ${report._id.toString()} - Caller: ${report.caller.upn} - User: ${report.user.userPrincipalName}`
 };
 
 await runInContext(logContext, async () => {

--- a/lib/handle-dust-report.ts
+++ b/lib/handle-dust-report.ts
@@ -1,5 +1,5 @@
 import { logger } from "@vestfoldfylke/loglady";
-import { type Collection, type MongoClient, ObjectId, type WithId } from "mongodb";
+import type { Collection, MongoClient, WithId } from "mongodb";
 import { MONGODB } from "../config.js";
 import type { AllSystemData } from "../types/system-data.js";
 import type { Report, SystemWithTestsResult } from "../types/system-tests.js";

--- a/lib/handle-dust-report.ts
+++ b/lib/handle-dust-report.ts
@@ -11,7 +11,7 @@ import { setupUserTests } from "./setup-user-tests.js";
 
 export const handleDustReport = async (report: WithId<Report>): Promise<void> => {
   const logContext = {
-    prefix: `handle-dust-report - Report Id: ${report._id} - Caller: ${report.caller.upn} - User: ${report.user.userPrincipalName}`
+    prefix: `handle-dust-report - Report Id: ${report._id.toString()} - Caller: ${report.caller.upn} - User: ${report.user.userPrincipalName}`
   };
 
   await runInContext(logContext, async () => {
@@ -29,7 +29,7 @@ export const handleDustReport = async (report: WithId<Report>): Promise<void> =>
     logger.info("Setting up systems and tests");
     const { systemsOverview, systemsToHandle } = await setupUserTests(report.user.userType);
 
-    collection.updateOne({ _id: new ObjectId(report._id) }, { $set: { systems: systemsOverview } });
+    collection.updateOne({ _id: report._id }, { $set: { systems: systemsOverview } });
     logger.info("Successfully set up systems and tests");
 
     const systemAndTestsPromises: Promise<SystemInWorkerResponse>[] = [];
@@ -70,7 +70,7 @@ export const handleDustReport = async (report: WithId<Report>): Promise<void> =>
 
     const serverRuntime: number = finishedTimestamp.getTime() - new Date(report.startedTimestamp).getTime();
     const totalRuntime: number = finishedTimestamp.getTime() - new Date(report.createdTimestamp).getTime();
-    await collection.updateOne({ _id: new ObjectId(report._id) }, { $set: { finishedTimestamp: finishedTimestamp.toISOString(), serverRuntime, totalRuntime, systems: systemsOverview } });
+    await collection.updateOne({ _id: report._id }, { $set: { finishedTimestamp: finishedTimestamp.toISOString(), serverRuntime, totalRuntime, systems: systemsOverview } });
 
     logger.info("Dust report finished");
     return "Finished";

--- a/lib/handle-system.ts
+++ b/lib/handle-system.ts
@@ -73,7 +73,7 @@ export const handleSystem = async (
 
   logger.info("handle-system - Finished running get-data-function and instant tests for system {SystemId}, saving to db", system.id);
   try {
-    mongoCollection.updateOne({ _id: new ObjectId(report._id), "systems.id": system.id }, { $set: { "systems.$": correspondingSystemInOverview } });
+    mongoCollection.updateOne({ _id: report._id, "systems.id": system.id }, { $set: { "systems.$": correspondingSystemInOverview } });
   } catch (err) {
     logger.errorException(err, "handle-system - Failed when updating corresponding system in overview for system {SystemId}", system.id);
   }

--- a/lib/handle-system.ts
+++ b/lib/handle-system.ts
@@ -1,5 +1,5 @@
 import { logger } from "@vestfoldfylke/loglady";
-import { type Collection, ObjectId, type WithId } from "mongodb";
+import type { Collection, WithId } from "mongodb";
 import type { AllSystemData, SystemData } from "../types/system-data.js";
 import type { Report, SystemTests, SystemWithTestsResult, TestCase } from "../types/system-tests.js";
 import type { GetData, SystemInWorkerResponse } from "../types/worker.js";

--- a/systems/azure/common-tests.ts
+++ b/systems/azure/common-tests.ts
@@ -430,7 +430,7 @@ export const azureAdInSync: TestCase = {
   waitForAllData: true,
   test: (user: TestUser, systemData: SystemData | undefined, allData: AllSystemData) => {
     if (!allData.ad) {
-      return error({ message: `Mangler data i ${systemNames.ad}`, raw: { user } });
+      return error({ message: `Mangler data i ${systemNames.ad}`, raw: { user }, solution: "Rettes i HR" });
     }
 
     if (isFailedSystemData(allData.ad)) {

--- a/systems/fint-ansatt/common-tests.ts
+++ b/systems/fint-ansatt/common-tests.ts
@@ -75,7 +75,7 @@ export const fintAnsattKategori: TestCase = {
       return error({
         message: `Kategorien på personalressursen (${category.kode}) er ekskludert, som tilsier at det ikke skal opprettes noen brukerkonto`,
         raw: category,
-        solution: "Meld sak til arbeidsgruppe IDM i Pureservice"
+        solution: "Rettes i HR"
       });
     }
 

--- a/systems/fint-larer/common-tests.ts
+++ b/systems/fint-larer/common-tests.ts
@@ -35,7 +35,7 @@ export const fintKontaktlarer: TestCase = {
     }
 
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Rettes i ${systemNames.vis}` });
     }
 
     const fintData: FintLarerSystemData = getSystemData<FintLarerSystemData>(systemData);
@@ -70,7 +70,7 @@ export const fintDuplicateKontaktlarergrupper: TestCase = {
     }
 
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Rettes i ${systemNames.vis}` });
     }
 
     const fintData: FintLarerSystemData = getSystemData<FintLarerSystemData>(systemData);
@@ -119,7 +119,7 @@ export const fintSkoleforhold: TestCase = {
     }
 
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Rettes i ${systemNames.vis}` });
     }
 
     const fintData: FintLarerSystemData = getSystemData<FintLarerSystemData>(systemData);
@@ -149,7 +149,7 @@ export const fintUndervisningsgrupper: TestCase = {
     }
 
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Rettes i ${systemNames.vis}` });
     }
 
     const fintData: FintLarerSystemData = getSystemData<FintLarerSystemData>(systemData);
@@ -192,7 +192,7 @@ export const fintFodselsnummer: TestCase = {
     }
 
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Rettes i ${systemNames.vis}` });
     }
 
     const fintData: FintLarerSystemData = getSystemData<FintLarerSystemData>(systemData);
@@ -233,7 +233,7 @@ export const fintMobilnummer: TestCase = {
     }
 
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Rettes i ${systemNames.vis}` });
     }
 
     const fintData: FintLarerSystemData = getSystemData<FintLarerSystemData>(systemData);
@@ -277,7 +277,7 @@ export const fintFeideVis: TestCase = {
     }
 
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.fintLarer}`, solution: `Rettes i ${systemNames.vis}` });
     }
 
     const fintData: FintLarerSystemData = getSystemData<FintLarerSystemData>(systemData);

--- a/systems/nettsperre/common-tests.ts
+++ b/systems/nettsperre/common-tests.ts
@@ -34,7 +34,7 @@ export const nettsperreHarNettsperre: TestCase = {
     }
 
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.nettsperre}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.nettsperre}`, solution: "Spør en voksen i vaktrommet" });
     }
 
     const nettsperreData: NettsperreSystemData = getSystemData<NettsperreSystemData>(systemData);
@@ -94,7 +94,7 @@ export const nettsperrePending: TestCase = {
   waitForAllData: false,
   test: (_user: TestUser, systemData: SystemData | undefined) => {
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.nettsperre}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.nettsperre}`, solution: "Spør en voksen i vaktrommet" });
     }
 
     const nettsperreData: NettsperreSystemData = getSystemData<NettsperreSystemData>(systemData);
@@ -120,7 +120,7 @@ export const nettsperreOverlappende: TestCase = {
   waitForAllData: false,
   test: (_user: TestUser, systemData: SystemData | undefined) => {
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.nettsperre}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.nettsperre}`, solution: "Spør en voksen i vaktrommet" });
     }
 
     const nettsperreData: NettsperreSystemData = getSystemData<NettsperreSystemData>(systemData);

--- a/systems/sync/common-tests.ts
+++ b/systems/sync/common-tests.ts
@@ -13,7 +13,7 @@ import systemNames from "../system-names.js";
   waitForAllData: false,
   test: (_user: TestUser, systemData: SystemData | undefined) => {
   if (!systemData) {
-      return warn({message: `Mangler data i ${systemNames.sync}`, solution: `Meld sak en plass`});
+      return warn({message: `Mangler data i ${systemNames.sync}`, solution: "Meld sak til arbeidsgruppe IDM i Pureservice"});
     }
 
     const syncData: SyncSystemData = getSystemData<SyncSystemData>(systemData);
@@ -42,7 +42,7 @@ export const syncAzure: TestCase = {
   waitForAllData: false,
   test: (_user: TestUser, systemData: SystemData | undefined) => {
     if (!systemData) {
-      return warn({ message: `Mangler data i ${systemNames.sync}`, solution: `Meld sak en plass` });
+      return warn({ message: `Mangler data i ${systemNames.sync}`, solution: "Meld sak til arbeidsgruppe IDM i Pureservice" });
     }
 
     const syncData: SyncSystemData = getSystemData<SyncSystemData>(systemData);

--- a/user-types/ansatt.ts
+++ b/user-types/ansatt.ts
@@ -26,7 +26,7 @@ export const systemsAndTests: SystemWithTestsAndData[] = [
         waitForAllData: false,
         test: (_user: TestUser, systemData: SystemData | undefined) => {
           if (!systemData) {
-            return warn({ message: `Mangler data i ${systemNames.azure}`, solution: `Rettes i ${systemNames.vis}` });
+            return warn({ message: `Mangler data i ${systemNames.ad}`, solution: `Rettes i ${systemNames.vis}` });
           }
 
           const adData: ADSystemData = getSystemData<ADSystemData>(systemData);


### PR DESCRIPTION
### Patch commits:
- fix: Use the ObjectId already present on the report (d90c00a)
- fix: Corrected some solutions made dumb in typescript migration (d86751a)
- fix: Corrected fint-ansatt test solution (c6f8337)

### Maintenance commits:
- chore: lint fix (8a7a58a)