### PR TITLE
patch: 2.0.0 - worker-fix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ import type { Collection, Db, MongoClient, WithId } from "mongodb";
 import { GET_NEW_REPORTS_INTERVAL, MONGODB } from "./config.js";
 import { handleDustReport } from "./lib/handle-dust-report.js";
 import { getMongoClient } from "./lib/mongo-client.js";
-import type { Report } from "./types/system-tests.js";
+import type { Report, ReportWithId } from "./types/system-tests.js";
 
 let readyForNewReports: boolean = true;
 
@@ -36,10 +36,12 @@ const getAndRunNewReports = async (): Promise<number | null> => {
     }
 
     newReports.forEach((report: WithId<Report>) => {
-      const merged: WithId<Report> = {
+      const merged: ReportWithId = {
         ...report,
-        ...updateProps
+        ...updateProps,
+        _id: report._id.toHexString()
       };
+
       handleDustReport(merged);
     });
 

--- a/indexThreader.ts
+++ b/indexThreader.ts
@@ -4,7 +4,7 @@ import { logger } from "@vestfoldfylke/loglady";
 import type { Collection, Db, MongoClient, WithId } from "mongodb";
 import { GET_NEW_REPORTS_INTERVAL, MONGODB } from "./config.js";
 import { getMongoClient } from "./lib/mongo-client.js";
-import type { Report } from "./types/system-tests.js";
+import type { Report, ReportWithId } from "./types/system-tests.js";
 
 const workerFile: string = fileURLToPath(new URL("./lib/dust-report-worker.js", import.meta.url));
 
@@ -39,9 +39,10 @@ const getAndRunNewReports = async (): Promise<number | null> => {
     }
 
     newReports.forEach((report: WithId<Report>) => {
-      const merged: WithId<Report> = {
+      const merged: ReportWithId = {
         ...report,
-        ...updateProps
+        ...updateProps,
+        _id: report._id.toHexString()
       };
 
       const worker = new Worker(workerFile, { workerData: merged });

--- a/lib/dust-report-worker.ts
+++ b/lib/dust-report-worker.ts
@@ -69,11 +69,7 @@ const handleSystemInWorker = async (
 
   correspondingSystemInOverview.finishedTimestamp = new Date().toISOString();
   if (!correspondingSystemInOverview.startedTimestamp) {
-    logger.warn(
-      "startedTimestamp is not set on correspondingSystemInOverview for system {System} in ReportId {ReportId}. Setting it to the same as finishedTimestamp",
-      system.id,
-      report._id
-    );
+    logger.warn("startedTimestamp is not set on correspondingSystemInOverview for system {System} in ReportId {ReportId}. Setting it to the same as finishedTimestamp", system.id, report._id);
     correspondingSystemInOverview.startedTimestamp = correspondingSystemInOverview.finishedTimestamp;
   }
   correspondingSystemInOverview.runtime = new Date(correspondingSystemInOverview.finishedTimestamp).getTime() - new Date(correspondingSystemInOverview.startedTimestamp).getTime();

--- a/lib/dust-report-worker.ts
+++ b/lib/dust-report-worker.ts
@@ -1,9 +1,9 @@
 import { parentPort, threadId, workerData } from "node:worker_threads";
 import { logger } from "@vestfoldfylke/loglady";
-import type { Collection, MongoClient, WithId } from "mongodb";
+import { type Collection, type MongoClient, ObjectId } from "mongodb";
 import { MONGODB } from "../config.js";
 import type { AllSystemData, SystemData } from "../types/system-data.js";
-import type { Report, SystemTests, SystemWithTestsResult, TestCase } from "../types/system-tests.js";
+import type { Report, ReportWithId, SystemTests, SystemWithTestsResult, TestCase } from "../types/system-tests.js";
 import type { GetData, SystemInWorkerResponse } from "../types/worker.js";
 import { runInContext } from "./async-local-context.js";
 import { CustomError } from "./CustomError.js";
@@ -16,7 +16,7 @@ parentPort?.postMessage("I started");
 const handleSystemInWorker = async (
   system: SystemTests,
   correspondingSystemInOverview: SystemWithTestsResult,
-  report: WithId<Report>,
+  report: ReportWithId,
   mongoCollection: Collection<Report>
 ): Promise<SystemInWorkerResponse> => {
   let getDataFunction: GetData;
@@ -72,19 +72,19 @@ const handleSystemInWorker = async (
     logger.warn(
       "startedTimestamp is not set on correspondingSystemInOverview for system {System} in ReportId {ReportId}. Setting it to the same as finishedTimestamp",
       system.id,
-      report._id.toString()
+      report._id
     );
     correspondingSystemInOverview.startedTimestamp = correspondingSystemInOverview.finishedTimestamp;
   }
   correspondingSystemInOverview.runtime = new Date(correspondingSystemInOverview.finishedTimestamp).getTime() - new Date(correspondingSystemInOverview.startedTimestamp).getTime();
 
   logger.info("Finished running get-data-function and instant tests for system {SystemId}, saving to db", system.id);
-  mongoCollection.updateOne({ _id: report._id, "systems.id": system.id }, { $set: { "systems.$": correspondingSystemInOverview } });
+  mongoCollection.updateOne({ _id: new ObjectId(report._id), "systems.id": system.id }, { $set: { "systems.$": correspondingSystemInOverview } });
 
   return { [system.id]: systemData };
 };
 
-const handleWaitingTestsInWorker = async (system: SystemTests, correspondingSystemInOverview: SystemWithTestsResult, report: WithId<Report>, allData: AllSystemData): Promise<void> => {
+const handleWaitingTestsInWorker = async (system: SystemTests, correspondingSystemInOverview: SystemWithTestsResult, report: ReportWithId, allData: AllSystemData): Promise<void> => {
   const testsToRun: TestCase[] = system.tests.filter((test: TestCase) => test.waitForAllData);
 
   for (const test of testsToRun) {
@@ -95,10 +95,10 @@ const handleWaitingTestsInWorker = async (system: SystemTests, correspondingSyst
   logger.info("Finished running waiting tests for system {SystemId}", system.id);
 };
 
-const report: WithId<Report> = workerData;
+const report: ReportWithId = workerData;
 
 const logContext = {
-  prefix: `dust-report-worker - Thread Id: ${threadId} - Report Id: ${report._id.toString()} - Caller: ${report.caller.upn} - User: ${report.user.userPrincipalName}`
+  prefix: `dust-report-worker - Thread Id: ${threadId} - Report Id: ${report._id} - Caller: ${report.caller.upn} - User: ${report.user.userPrincipalName}`
 };
 
 await runInContext(logContext, async () => {
@@ -116,7 +116,7 @@ await runInContext(logContext, async () => {
   logger.info("Setting up systems and tests");
   const { systemsOverview, systemsToHandle } = await setupUserTests(report.user.userType);
 
-  collection.updateOne({ _id: report._id }, { $set: { systems: systemsOverview } });
+  collection.updateOne({ _id: new ObjectId(report._id) }, { $set: { systems: systemsOverview } });
   logger.info("Successfully set up systems and tests");
 
   const systemAndTestsPromises: Promise<SystemInWorkerResponse>[] = [];
@@ -151,13 +151,13 @@ await runInContext(logContext, async () => {
   const finishedTimestamp: Date = new Date();
 
   if (!report.startedTimestamp) {
-    logger.warn("startedTimestamp is not set on ReportId {ReportId}. Setting it to the same as finishedTimestamp", report._id.toString());
+    logger.warn("startedTimestamp is not set on ReportId {ReportId}. Setting it to the same as finishedTimestamp", report._id);
     report.startedTimestamp = finishedTimestamp.toISOString();
   }
 
   const serverRuntime: number = finishedTimestamp.getTime() - new Date(report.startedTimestamp).getTime();
   const totalRuntime: number = finishedTimestamp.getTime() - new Date(report.createdTimestamp).getTime();
-  await collection.updateOne({ _id: report._id }, { $set: { finishedTimestamp: finishedTimestamp.toISOString(), serverRuntime, totalRuntime, systems: systemsOverview } });
+  await collection.updateOne({ _id: new ObjectId(report._id) }, { $set: { finishedTimestamp: finishedTimestamp.toISOString(), serverRuntime, totalRuntime, systems: systemsOverview } });
 
   await closeMongoClient();
   logger.info("Finished report");

--- a/lib/handle-dust-report.ts
+++ b/lib/handle-dust-report.ts
@@ -1,17 +1,17 @@
 import { logger } from "@vestfoldfylke/loglady";
-import type { Collection, MongoClient, WithId } from "mongodb";
+import { type Collection, type MongoClient, ObjectId } from "mongodb";
 import { MONGODB } from "../config.js";
 import type { AllSystemData } from "../types/system-data.js";
-import type { Report, SystemWithTestsResult } from "../types/system-tests.js";
+import type { Report, ReportWithId, SystemWithTestsResult } from "../types/system-tests.js";
 import type { SystemInWorkerResponse } from "../types/worker.js";
 import { runInContext } from "./async-local-context.js";
 import { handleSystem, handleWaitingTests } from "./handle-system.js";
 import { getMongoClient } from "./mongo-client.js";
 import { setupUserTests } from "./setup-user-tests.js";
 
-export const handleDustReport = async (report: WithId<Report>): Promise<void> => {
+export const handleDustReport = async (report: ReportWithId): Promise<void> => {
   const logContext = {
-    prefix: `handle-dust-report - Report Id: ${report._id.toString()} - Caller: ${report.caller.upn} - User: ${report.user.userPrincipalName}`
+    prefix: `handle-dust-report - Report Id: ${report._id} - Caller: ${report.caller.upn} - User: ${report.user.userPrincipalName}`
   };
 
   await runInContext(logContext, async () => {
@@ -29,7 +29,7 @@ export const handleDustReport = async (report: WithId<Report>): Promise<void> =>
     logger.info("Setting up systems and tests");
     const { systemsOverview, systemsToHandle } = await setupUserTests(report.user.userType);
 
-    collection.updateOne({ _id: report._id }, { $set: { systems: systemsOverview } });
+    collection.updateOne({ _id: new ObjectId(report._id) }, { $set: { systems: systemsOverview } });
     logger.info("Successfully set up systems and tests");
 
     const systemAndTestsPromises: Promise<SystemInWorkerResponse>[] = [];
@@ -64,13 +64,13 @@ export const handleDustReport = async (report: WithId<Report>): Promise<void> =>
     const finishedTimestamp: Date = new Date();
 
     if (!report.startedTimestamp) {
-      logger.warn("startedTimestamp is not set on ReportId {ReportId}. Setting it to the same as finishedTimestamp", report._id.toString());
+      logger.warn("startedTimestamp is not set on ReportId {ReportId}. Setting it to the same as finishedTimestamp", report._id);
       report.startedTimestamp = finishedTimestamp.toISOString();
     }
 
     const serverRuntime: number = finishedTimestamp.getTime() - new Date(report.startedTimestamp).getTime();
     const totalRuntime: number = finishedTimestamp.getTime() - new Date(report.createdTimestamp).getTime();
-    await collection.updateOne({ _id: report._id }, { $set: { finishedTimestamp: finishedTimestamp.toISOString(), serverRuntime, totalRuntime, systems: systemsOverview } });
+    await collection.updateOne({ _id: new ObjectId(report._id) }, { $set: { finishedTimestamp: finishedTimestamp.toISOString(), serverRuntime, totalRuntime, systems: systemsOverview } });
 
     logger.info("Dust report finished");
     return "Finished";

--- a/lib/handle-system.ts
+++ b/lib/handle-system.ts
@@ -1,7 +1,7 @@
 import { logger } from "@vestfoldfylke/loglady";
-import type { Collection, WithId } from "mongodb";
+import { type Collection, ObjectId } from "mongodb";
 import type { AllSystemData, SystemData } from "../types/system-data.js";
-import type { Report, SystemTests, SystemWithTestsResult, TestCase } from "../types/system-tests.js";
+import type { Report, ReportWithId, SystemTests, SystemWithTestsResult, TestCase } from "../types/system-tests.js";
 import type { GetData, SystemInWorkerResponse } from "../types/worker.js";
 import { CustomError } from "./CustomError.js";
 import { HTTPError } from "./helpers/HTTPError.js";
@@ -9,7 +9,7 @@ import { HTTPError } from "./helpers/HTTPError.js";
 export const handleSystem = async (
   system: SystemTests,
   correspondingSystemInOverview: SystemWithTestsResult,
-  report: WithId<Report>,
+  report: ReportWithId,
   mongoCollection: Collection<Report>
 ): Promise<SystemInWorkerResponse> => {
   let getDataFunction: GetData;
@@ -65,7 +65,7 @@ export const handleSystem = async (
     logger.warn(
       "startedTimestamp is not set on correspondingSystemInOverview for system {System} in ReportId {ReportId}. Setting it to the same as finishedTimestamp",
       system.id,
-      report._id.toString()
+      report._id
     );
     correspondingSystemInOverview.startedTimestamp = correspondingSystemInOverview.finishedTimestamp;
   }
@@ -73,7 +73,7 @@ export const handleSystem = async (
 
   logger.info("handle-system - Finished running get-data-function and instant tests for system {SystemId}, saving to db", system.id);
   try {
-    mongoCollection.updateOne({ _id: report._id, "systems.id": system.id }, { $set: { "systems.$": correspondingSystemInOverview } });
+    mongoCollection.updateOne({ _id: new ObjectId(report._id), "systems.id": system.id }, { $set: { "systems.$": correspondingSystemInOverview } });
   } catch (err) {
     logger.errorException(err, "handle-system - Failed when updating corresponding system in overview for system {SystemId}", system.id);
   }
@@ -81,7 +81,7 @@ export const handleSystem = async (
   return { [system.id]: systemData };
 };
 
-export const handleWaitingTests = async (system: SystemTests, correspondingSystemInOverview: SystemWithTestsResult, report: WithId<Report>, allData: AllSystemData): Promise<void> => {
+export const handleWaitingTests = async (system: SystemTests, correspondingSystemInOverview: SystemWithTestsResult, report: ReportWithId, allData: AllSystemData): Promise<void> => {
   const testsToRun: TestCase[] = system.tests.filter((test: TestCase) => test.waitForAllData);
 
   for (const test of testsToRun) {

--- a/lib/handle-system.ts
+++ b/lib/handle-system.ts
@@ -62,11 +62,7 @@ export const handleSystem = async (
 
   correspondingSystemInOverview.finishedTimestamp = new Date().toISOString();
   if (!correspondingSystemInOverview.startedTimestamp) {
-    logger.warn(
-      "startedTimestamp is not set on correspondingSystemInOverview for system {System} in ReportId {ReportId}. Setting it to the same as finishedTimestamp",
-      system.id,
-      report._id
-    );
+    logger.warn("startedTimestamp is not set on correspondingSystemInOverview for system {System} in ReportId {ReportId}. Setting it to the same as finishedTimestamp", system.id, report._id);
     correspondingSystemInOverview.startedTimestamp = correspondingSystemInOverview.finishedTimestamp;
   }
   correspondingSystemInOverview.runtime = new Date(correspondingSystemInOverview.finishedTimestamp).getTime() - new Date(correspondingSystemInOverview.startedTimestamp).getTime();

--- a/types/system-tests.ts
+++ b/types/system-tests.ts
@@ -19,6 +19,10 @@ export type Report = {
   systems: SystemWithTestsResult[];
 };
 
+export type ReportWithId = Report & {
+  _id: string;
+};
+
 export type SystemWithTestsAndData = {
   id: "ad" | "azure" | "fint-ansatt" | "fint-elev" | "fint-larer" | "info" | "nettsperre" | "sync" | "feide";
   name: string;


### PR DESCRIPTION
### Patch commits:
- fix: node:worker_threads passes the workerData through the `structured clone algorithm`, effectivly making the BSON object _id into a regular object without BSON's functions (a3ddf4b)

### Maintenance commits:
- chore: lint fix (722ac24)
